### PR TITLE
Feat. lists as input for searchTerm, category, and endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@triply/triplydb": "^4.2.1",
     "figlet": "^1.5.2",
+    "lodash": "^4.17.21",
     "node-fetch": "^2.6.7",
     "yargs": "^17.5.1",
     "yargs-interactive": "^3.0.1"

--- a/src/elasticsearch.ts
+++ b/src/elasticsearch.ts
@@ -16,7 +16,7 @@ interface ShardResponse {
 }
 
 // Defines the shape of the Elasticsearch recommendations.
-interface AutocompleteSuggestion {
+export interface Result {
   iri: string;
   description?: string;
 }
@@ -106,7 +106,7 @@ export function assignElasticQuery(category: string, term: string) {
  */
 export function getSuggestionFromBody(
   responseBody: ShardResponse
-): AutocompleteSuggestion[] {
+): Result[] {
   return responseBody.hits.hits.map(suggestion => {
     const rdfs_comment = "http://www w3 org/2000/01/rdf-schema#comment"
     const skos_definition = "http://www w3 org/2004/02/skos/core#definition"

--- a/src/sparql.ts
+++ b/src/sparql.ts
@@ -1,5 +1,5 @@
 // Defines the shape of the SPARQL recommendations.
-export interface SparqlResult {
+export interface Result {
   iri: string;
   description: string;
 }
@@ -119,7 +119,7 @@ export async function sparqlSuggestions(
 
   if (result.ok) {
     const json: any = await result.json();
-    const sparqlResults: SparqlResult[] = [];
+    const sparqlResults: Result[] = [];
     for (let row of json) {
       const rowResults: any = {};
       for (const key of Object.keys(row)) {


### PR DESCRIPTION
Changes to structure of the run() function and unified the naming for SPARQL and ES return objects in sparql.ts & elasticsearch.ts. New feature implemented where user can give multiple search terms and corresponding categories. Additionally user can give multiple endpoints that will each be queried, returning a unique set of found results.